### PR TITLE
README: Add a link to the personal access token creation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Cleans up old and inactive forks on your GitHub account.
 
-You'll need to create a personal access token with `repo` and `delete_repo`
+You'll need to [create a personal access token](https://github.com/settings/tokens/new?scopes=repo,delete_repo&description=fork-cleaner) with `repo` and `delete_repo`
 permissions.
 
 Then, [download the latest release](https://github.com/caarlos0/fork-cleaner/releases)


### PR DESCRIPTION
This pre-fills the form with a description and the correct scopes, so one only has to click on "Generate token".