### PR TITLE
docs: clarify that blacklist takes repo names only

### DIFF
--- a/cmd/fork-cleaner/main.go
+++ b/cmd/fork-cleaner/main.go
@@ -39,7 +39,7 @@ func main() {
 		},
 		cli.StringSliceFlag{
 			Name:  "blacklist, exclude, b",
-			Usage: "Blacklist of repos that shouldn't be removed",
+			Usage: "Blacklist of repos that shouldn't be removed (names only)",
 		},
 		cli.DurationFlag{
 			Name:  "no-activity-since, since",


### PR DESCRIPTION
This makes it clearer (IMO) that blacklist specifications should only have repo names, not full URL's.