### PR TITLE
feat: add ability to exclude forks ahead of parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Fork-Cleaner will show you repos that:
 - had no activity in the last 1 month (customizable via `--since`);
 - are not private (customizable via `--include-private,`);
 - are not blacklisted (customizable via `--blacklist`).
+- are even with or behind the upstream repo (customizable via `--exclude-commits-ahead`).
 
 fork-cleaner will list them and ask if you want to remove them! Simple as that.
 

--- a/cmd/fork-cleaner/main.go
+++ b/cmd/fork-cleaner/main.go
@@ -37,6 +37,10 @@ func main() {
 			Name:  "include-private, p",
 			Usage: "Include private repositories",
 		},
+		cli.BoolFlag{
+			Name:  "exclude-commits-ahead, a",
+			Usage: "Exclude repositories with commits ahead of parent",
+		},
 		cli.StringSliceFlag{
 			Name:  "blacklist, exclude, b",
 			Usage: "Blacklist of repos that shouldn't be removed (names only)",
@@ -62,9 +66,10 @@ func main() {
 		var sg = spin.New("\033[36m %s Gathering data...\033[m")
 		sg.Start()
 		var filter = forkcleaner.Filter{
-			Blacklist:      blacklist,
-			IncludePrivate: c.Bool("include-private"),
-			Since:          c.Duration("since"),
+			Blacklist:           blacklist,
+			IncludePrivate:      c.Bool("include-private"),
+			Since:               c.Duration("since"),
+			ExcludeCommitsAhead: c.Bool("exclude-commits-ahead"),
 		}
 		forks, err := forkcleaner.Find(ctx, client, filter)
 		sg.Stop()


### PR DESCRIPTION
@caarlos0 thanks for this cool tool! 

this PR adds an optional parameter to allow excluding forks which have commits ahead of the parent repo. 