### PR TITLE
feat: show fork exclusion reason

### DIFF
--- a/cmd/fork-cleaner/main.go
+++ b/cmd/fork-cleaner/main.go
@@ -41,6 +41,10 @@ func main() {
 			Name:  "exclude-commits-ahead, a",
 			Usage: "Exclude repositories with commits ahead of parent",
 		},
+		cli.BoolFlag{
+			Name:  "show-exclusion-reason",
+			Usage: "Show the reason a fork is excluded",
+		},
 		cli.StringSliceFlag{
 			Name:  "blacklist, exclude, b",
 			Usage: "Blacklist of repos that shouldn't be removed (names only)",
@@ -70,11 +74,19 @@ func main() {
 			IncludePrivate:      c.Bool("include-private"),
 			Since:               c.Duration("since"),
 			ExcludeCommitsAhead: c.Bool("exclude-commits-ahead"),
+			ShowExcludeReason:   c.Bool("show-exclusion-reason"),
 		}
-		forks, err := forkcleaner.Find(ctx, client, filter)
+		forks, excludedForks, err := forkcleaner.Find(ctx, client, filter)
 		sg.Stop()
 		if err != nil {
 			return cli.NewExitError(err.Error(), 1)
+		}
+		if filter.ShowExcludeReason && len(excludedForks) > 0 {
+			log.Println(len(excludedForks), "forks excluded from deletion:")
+			for _, f := range excludedForks {
+				log.Print(f)
+			}
+			log.Println()
 		}
 		if len(forks) == 0 {
 			log.Println("0 forks to delete!")


### PR DESCRIPTION
This PR adds a optional parameter to provide verbose output on which forks were excluded from automatic deletion and the reason for the exclusion. The reason I wanted this is so that I could manually review the excluded forks in the event I still wanted to manually delete some of the forks.

This did require non-backwards compatible changes to the `forkcleaner` package so no hard feelings if you reject the PR :smiley: . 

<details>
 <summary>Sample output from my account:</summary>

```
❯ fork-cleaner -a --show-exclusion-reason
15 forks excluded:
https://github.com/jakewarren/dnstwist excluded because: repo has 1 stars
https://github.com/jakewarren/elite-proxy-finder excluded because: repo has 1 forks
https://github.com/jakewarren/fork-cleaner excluded because: repo has recent activity (last update on 11/14/2019)
https://github.com/jakewarren/gcrt excluded because: repo has 1 stars
https://github.com/jakewarren/gif excluded because: repo is 3 commits ahead of parent
https://github.com/jakewarren/gist-backup excluded because: repo is 1 commits ahead of parent
https://github.com/jakewarren/GitStalker excluded because: repo is 3 commits ahead of parent
https://github.com/jakewarren/go-ouitools excluded because: repo is 2 commits ahead of parent
https://github.com/jakewarren/image2ascii excluded because: repo is 3 commits ahead of parent
https://github.com/jakewarren/ipisp excluded because: repo is 1 commits ahead of parent
https://github.com/jakewarren/kali-metasploit excluded because: repo is 1 commits ahead of parent
https://github.com/jakewarren/metascraper excluded because: repo has recent activity (last update on 11/11/2019)
https://github.com/jakewarren/runefinder excluded because: repo is 7 commits ahead of parent
https://github.com/jakewarren/slurp excluded because: repo has 1 forks
https://github.com/jakewarren/tldomains excluded because: repo has 1 stars

11 forks to delete:
 --> https://github.com/jakewarren/awesome-readme
 --> https://github.com/jakewarren/combine
 --> https://github.com/jakewarren/contributing-template
 --> https://github.com/jakewarren/figlet-fonts
 --> https://github.com/jakewarren/firefox-tweaks
 --> https://github.com/jakewarren/iocminion
 --> https://github.com/jakewarren/joe
 --> https://github.com/jakewarren/journal
 --> https://github.com/jakewarren/onionscan
 --> https://github.com/jakewarren/readme-template
 --> https://github.com/jakewarren/rule2alert
Remove the above listed forks? (y/n) [n]: n
OK, exiting
```
</details>
