### PR TITLE
README: Change `console` to `sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ permissions.
 Then, [download the latest release](https://github.com/caarlos0/fork-cleaner/releases)
 and execute the binary as in:
 
-```console
+```sh
 ./fork-cleaner --token "my github token"
 ```
 
@@ -38,13 +38,13 @@ fork-cleaner will list them and ask if you want to remove them! Simple as that.
 
 On macOS:
 
-```console
+```sh
 brew install fork-cleaner
 ```
 
 On Linux:
 
-```console
+```sh
 snap install fork-cleaner
 ```
 


### PR DESCRIPTION
`console` is an alias for `sh-session`, in which commands are prefixed with the symbol `$` or `>`. For example:

```sh-session
$ gem install nokogiri
...
Building native extensions. This could take a while...
...
```